### PR TITLE
#1: Bug fix - Backpropagation assigns same value to both players

### DIFF
--- a/Sources/Carlo/CarloGamePlayer.swift
+++ b/Sources/Carlo/CarloGamePlayer.swift
@@ -14,4 +14,4 @@ import Foundation
 ///     case white
 /// }
 /// ```
-public protocol CarloGamePlayer {}
+public protocol CarloGamePlayer: Equatable {}

--- a/Sources/Carlo/CarloTacticianNode.swift
+++ b/Sources/Carlo/CarloTacticianNode.swift
@@ -92,7 +92,8 @@ extension CarloTactician {
             cumulativeValue += value
             visits += n
             if let parent = parent {
-                parent.backpropagate(value, visits: n)
+                assert(game.currentPlayer != parent.game.currentPlayer, "`currentPlayer` needs to change with every move")
+                parent.backpropagate(1 - value, visits: n)
             }
         }
         

--- a/Tests/CarloTests/ConnectThreeTests.swift
+++ b/Tests/CarloTests/ConnectThreeTests.swift
@@ -2,7 +2,8 @@
     @testable import Carlo
 
     final class CarloTests: XCTestCase {
-        func testConnectThree() {
+
+        func testFindOwnWinningMove() {
             typealias Computer = CarloTactician<ConnectThreeGame>
             let computer = Computer(for: .two, maxRolloutDepth: 5)
             var game = ConnectThreeGame(length: 10, currentPlayer: .one)
@@ -14,6 +15,23 @@
             // player 2 can win if move = 1
             computer.uproot(to: game)
             for _ in 0..<50 {
+                computer.iterate()
+            }
+            let move = computer.bestMove!
+            XCTAssertEqual(move, 1)
+        }
+
+        func testPreventOpponentsWinningMove() {
+            typealias Computer = CarloTactician<ConnectThreeGame>
+            let computer = Computer(for: .two, maxRolloutDepth: 5)
+            var game = ConnectThreeGame(length: 10, currentPlayer: .one)
+            game = game.update(4) // player 1
+            game = game.update(0) // player 2
+            game = game.update(7) // player 1
+            game = game.update(2) // player 2
+            // player 2 could win next move, if move = 1. So player 1 needs to prevent that.
+            computer.uproot(to: game)
+            for _ in 0..<250 {
                 computer.iterate()
             }
             let move = computer.bestMove!


### PR DESCRIPTION
Backpropagation should assign "1" as value to a node in case of win
and "0" in case of loss. The current implementation assigns after a
rollout the same value to all nodes. It should however assign different
values, depending on who is the currentPlayer. Right now for one player
not the best moves are picked during the Selection phase, but the worst
moves. Because of this the algorithm picks rather random moves.

This bug fix always assigns the "opposite" value to parent nodes:
- 1 in case of 0
- 0 in case of 1
- 0.5 in case 0.5

This only works for games where the `currentPlayer` changes after each
move. If `currentPlayer` could be the same after a certain move, we
would have to check whose turn it is during backprogation, that would
be a bit more effort for both the programmer and the computer.